### PR TITLE
BREAKING CHANGE: Switched band_order default for get_band_info

### DIFF
--- a/CASTEPbands/Spectral.py
+++ b/CASTEPbands/Spectral.py
@@ -481,7 +481,7 @@ class Spectral:
 
         return
 
-    def get_band_info(self, silent=False, bandwidth=None, band_order='F', ret_vbm_cbm=False):
+    def get_band_info(self, silent=False, bandwidth=None, band_order='C', ret_vbm_cbm=False):
         """Get a summary of the band structure.
 
         Author: V Ravindran (30/01/2024)
@@ -498,7 +498,7 @@ class Spectral:
         band_order : string
             Type of array ordering to use when deciding which band to use for band width
             measurements. CASTEP uses Fortran ordering (arrays start from 1).
-            (default : 'F')
+            (default : 'C')
         ret_vbm_cbm : boolean
             Return the index of the kpoint required to get the valence band maximum and conduction band minimum
             together with the respective eigenvalues.


### PR DESCRIPTION
Currently, the default for the `band_order` keyword argument in the `get_band_info` method is Fortran (`'F'`). However, given this is in Python, most people would logically assume the script uses C/Python indexing conventions, namely starting from an index of 0 rather than 1. 

Hence to avoid confusion, it is probably best to make C ordering the default. 

This may be a potentially breaking change although it will only affect bandwidth calculations for a _specific_ band if requested by the user, the rest of the code is unaffected. 