### PR TITLE
Updated handling for high-symmetry labels 

### DIFF
--- a/CASTEPbands/Spectral.py
+++ b/CASTEPbands/Spectral.py
@@ -20,6 +20,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from ase.data import atomic_numbers
 
+from CASTEPbands import spgutils
+
 
 class Spectral:
     """
@@ -52,10 +54,14 @@ class Spectral:
          Band structure is from non-collinear calculation.
          This basically instructs overrides double occupancy despites nspins=1 as from
         .bands file alone, non-collinear magnetism alone cannot be inferred (default: False)
-    high_sym_spacegroup
+    high_sym_spacegroup : boolean
          Get the high-symmetry points from the space group rather than just the
-          geometry/lattice parameters of the computational cell (Default : True)
-    use_cell:
+         geometry/lattice parameters of the computational cell (Default : True)
+    override_bv : boolean
+         Set a Bravais lattice manually and use this Bravais lattice for the high-symmetry point labels.
+         This may be useful when the cell contains e.g. a defect and one wishes to
+         nonetheless keep the high-symmetry points of the original crystal for the plot.
+    use_cell: boolean
          Cell file containing structure used for band structure
          (Default : <seed>.cell)
     vec_spin : boolean
@@ -88,6 +94,7 @@ class Spectral:
                  flip_spins=False,
                  have_ncm=False,
                  high_sym_spacegroup=True,
+                 override_bv=None,
                  use_cell=None,
                  vec_spin=False):
         ''' Initalise the class, it will require the CASTEP seed to read the file '''
@@ -334,105 +341,7 @@ class Spectral:
         high_sym = np.array(high_sym) + 1
         self.high_sym = high_sym
 
-        # Set up the special points
-        def _get_high_sym_points_spg(cell):
-            """Determine the high-symmetry points uisng the spacegroup.
-
-            ASE will use just use the crystal system based on solely the lattice parameters
-            whereas CASTEP will utilise the space group, which will be particularly important
-            in e.g. magnetic materials where the computational cell may have a different crystal system
-            to the (conventional) crystallographic one.
-
-            For low-symmetry Bravais lattices where the special/high-symmetry points are
-            lattice parameter dependent, we will use the lattice parameters of the computational cell.
-
-            Author : V Ravindran 08/05/2024
-            """
-            import ase.spacegroup as spg
-            import ase.lattice as latt
-
-            # Get all the Bravais lattices
-            bv_dict = latt.bravais_lattices
-
-            # Get the cell's lattice parameters
-            a, b, c, alpha, beta, gamma = cell.cell.cellpar()
-
-            # Get the space group information for this cell
-            spg_cell = spg.get_spacegroup(cell)
-            spg_no = spg_cell.no
-
-            # Get the first letter of the spacegroup in international notation.
-            # This gives the information about the Bravais lattice
-            bv_symb = spg_cell.symbol.split()[0].upper()
-
-            # Now use the space group to determine the crystal system.
-            # We can determine the actual Bravais lattice using the first
-            # letter of the international notation symbol.
-            #
-            # Like in CASTEP, particularly for low symmetry Bravais lattices
-            # where the high symmetry points depend on lattice parameters,
-            # we will use the computational cell's lattice parameters.
-            # Variations for each bravais lattice should be handled by ASE (in principle...)
-            if 1 <= spg_no <= 2:
-                # Triclinic lattice
-                bv = bv_dict['TRI'](a=a, b=b, c=c,
-                                    alpha=alpha, beta=beta, gamma=gamma)
-            elif 3 <= spg_no <= 15:
-                # Monoclinic
-                if bv_symb == 'P':  # Primitive monoclinic
-                    bv = bv_dict['MCL'](a=a, b=b, c=c,
-                                        alpha=alpha)
-                elif bv_symb == 'C':  # Base-centred (C-centred) monoclinic
-                    bv = bv_dict['MCLC'](a=a, b=b, c=c,
-                                         alpha=alpha)
-                else:
-                    raise IndexError(f'Unknown monoclinic lattice with space group: {spg_cell.symbol}')
-            elif 16 <= spg_no <= 74:
-                # Orthorhombic
-                if bv_symb == 'P':  # Primitive Orthorhombic
-                    bv = bv_dict['ORC'](a=a, b=b, c=c)
-                elif bv_symb == 'I':  # Body-Centred Orthorhombic
-                    bv = bv_dict['ORCI'](a=a, b=b, c=c)
-                elif bv_symb == 'F':  # Face-Centred Orthorhombic
-                    bv = bv_dict['ORCF'](a=a, b=b, c=c)
-                elif bv_symb == 'A' or bv_symb == 'C':  # A/C-centred
-                    bv = bv_dict['ORCC'](a=a, b=b, c=c)
-                else:
-                    raise IndexError(f'Unknown orthorhombic lattice with space group: {spg_cell.symbol}')
-            elif 75 <= spg_no <= 142:
-                # Tetragonal
-                if bv_symb == 'P':  # Primitive Tetragonal
-                    bv = bv_dict['TET'](a=a, c=c)
-                elif bv_symb == 'I':  # Body-Centred Tetragonal
-                    bv = bv_dict['BCT'](a=a, c=c)
-                else:
-                    raise IndexError(f'Unknown tetragonal lattice with space group: {spg_cell.symbol}')
-            elif 143 <= spg_no <= 167:
-                # Trigonal
-                if bv_symb == 'R':  # R-trigonal/Rhombohedral
-                    bv = bv_dict['RHL'](a=a, alpha=alpha)
-                elif bv_symb == 'P':  # Hexagonal
-                    bv = bv_dict['HEX'](a=a, c=c)
-                else:
-                    raise IndexError(f'Unknown trigonal lattice with space group: {spg_cell.symbol}')
-            elif 168 <= spg_no <= 194:
-                # Hexagonal
-                bv = bv_dict['HEX'](a=a, c=c)
-            elif 195 <= spg_no <= 230:
-                # Cubic
-                if bv_symb == 'P':  # Primitive/Simple Cubic
-                    bv = bv_dict['CUB'](a=a)
-                elif bv_symb == 'I':  # Body-Centred Cubic
-                    bv = bv_dict['BCC'](a=a)
-                elif bv_symb == 'F':  # Face-Centred Cubic
-                    bv = bv_dict['FCC'](a=a)
-                else:
-                    raise IndexError(f'Unknown cubic lattice with space group: {spg_cell.symbol}')
-            else:
-                raise IndexError(f'Unknown Spacegroup {spg_no}: {spg_cell.symbol}')
-
-            return bv.get_special_points()
-
+        # Obtain the unit cell for this calculation
         # This used to write to os.devnull because ASE would whinge about a missing CASTEP executable. V Ravindran CELL_READ 01/05/2024
         # There is a way to correct this however using an ASE keyword.                                 V Ravindran CELL_READ 01/05/2024
         # Moreover, this ensures that the JSON file for CASTEP will not be set up if the               V Ravindran CELL_READ 01/05/2024
@@ -449,13 +358,20 @@ class Spectral:
                            calculator_args={"keyword_tolerance": 3}
                            )
 
-        # Default for special points is now to get them from the space group. V Ravindran 08/05/2024
-        if high_sym_spacegroup is True:
-            special_points = _get_high_sym_points_spg(cell)
+        # Set up the special points
+        if override_bv is not None:
+            # Allow user to manually specify the Bravais lattice.   V Ravindran OVERRIDE_BV 28/08/2024
+            # Useful for defect calculations if one wants to        V Ravindran OVERRIDE_BV 28/08/2024
+            # e.g. use high-symmetry labels of the main crystal.    V Ravindran OVERRIDE_BV 28/08/2024
+            bv_latt = spgutils._get_bravais_lattice_usr(cell, override_bv)
+        elif high_sym_spacegroup is True:
+            # Default for special points is now to get them from the space group. V Ravindran 08/05/2024
+            bv_latt = spgutils._get_bravais_lattice_spg(cell)
         else:
-            # Get special from the crystal system of the computational cell.
+            # Get Bravais lattice from the crystal system of the computational cell.
             bv_latt = cell.cell.get_bravais_lattice()
-            special_points = bv_latt.get_special_points()
+
+        special_points = bv_latt.get_special_points()
 
         # Get the atoms in cell.
         atoms = np.unique(cell.get_chemical_symbols())[::-1]

--- a/CASTEPbands/spgutils.py
+++ b/CASTEPbands/spgutils.py
@@ -21,7 +21,12 @@ def _get_bravais_lattice_spg(cell):
     lattice parameter dependent, we will use the lattice parameters of the computational cell.
 
     Author : V Ravindran 08/05/2024
-    Moved from Spectral to here and updated to return the Bravais lattice itself instead 28/08/2024
+
+    Updated: 28/08/2024
+    * Moved from Spectral to here
+    * Now returns the Bravais lattice itself rather than the high symmetry points
+    * Wraps to _get_bravais_lattice_usr to actually get the Bravais lattice
+      saving on some duplication of code.
 
     """
     # Get all the Bravais lattices
@@ -48,62 +53,61 @@ def _get_bravais_lattice_spg(cell):
     # Variations for each bravais lattice should be handled by ASE (in principle...)
     if 1 <= spg_no <= 2:
         # Triclinic lattice
-        bv = bv_dict['TRI'](a=a, b=b, c=c,
-                            alpha=alpha, beta=beta, gamma=gamma)
+        bv_type = 'TRI'
     elif 3 <= spg_no <= 15:
         # Monoclinic
         if bv_symb == 'P':  # Primitive monoclinic
-            bv = bv_dict['MCL'](a=a, b=b, c=c,
-                                alpha=alpha)
+            bv_type = 'MCL'
         elif bv_symb == 'C':  # Base-centred (C-centred) monoclinic
-            bv = bv_dict['MCLC'](a=a, b=b, c=c,
-                                 alpha=alpha)
+            bv_type = 'MCLC'
         else:
             raise IndexError(f'Unknown monoclinic lattice with space group: {spg_cell.symbol}')
     elif 16 <= spg_no <= 74:
         # Orthorhombic
         if bv_symb == 'P':  # Primitive Orthorhombic
-            bv = bv_dict['ORC'](a=a, b=b, c=c)
+            bv_type = 'ORC'
         elif bv_symb == 'I':  # Body-Centred Orthorhombic
-            bv = bv_dict['ORCI'](a=a, b=b, c=c)
+            bv_type = 'ORCI'
         elif bv_symb == 'F':  # Face-Centred Orthorhombic
-            bv = bv_dict['ORCF'](a=a, b=b, c=c)
-        elif bv_symb == 'A' or bv_symb == 'C':  # A/C-centred
-            bv = bv_dict['ORCC'](a=a, b=b, c=c)
+            bv_type = 'ORCF'
+        elif bv_symb == 'A' or bv_symb == 'C':  # A/C-centred Orthorhombic
+            bv_type = 'ORCC'
         else:
             raise IndexError(f'Unknown orthorhombic lattice with space group: {spg_cell.symbol}')
     elif 75 <= spg_no <= 142:
         # Tetragonal
         if bv_symb == 'P':  # Primitive Tetragonal
-            bv = bv_dict['TET'](a=a, c=c)
+            bv_type = 'TET'
         elif bv_symb == 'I':  # Body-Centred Tetragonal
-            bv = bv_dict['BCT'](a=a, c=c)
+            bv_type = 'BCT'
         else:
             raise IndexError(f'Unknown tetragonal lattice with space group: {spg_cell.symbol}')
     elif 143 <= spg_no <= 167:
         # Trigonal
         if bv_symb == 'R':  # R-trigonal/Rhombohedral
-            bv = bv_dict['RHL'](a=a, alpha=alpha)
+            bv_type = 'RHL'
         elif bv_symb == 'P':  # Hexagonal
-            bv = bv_dict['HEX'](a=a, c=c)
+            bv_type = 'HEX'
         else:
             raise IndexError(f'Unknown trigonal lattice with space group: {spg_cell.symbol}')
     elif 168 <= spg_no <= 194:
         # Hexagonal
-        bv = bv_dict['HEX'](a=a, c=c)
+        bv_type = 'HEX'
     elif 195 <= spg_no <= 230:
         # Cubic
         if bv_symb == 'P':  # Primitive/Simple Cubic
-            bv = bv_dict['CUB'](a=a)
+            bv_type = 'CUB'
         elif bv_symb == 'I':  # Body-Centred Cubic
-            bv = bv_dict['BCC'](a=a)
+            bv_type = 'BCC'
         elif bv_symb == 'F':  # Face-Centred Cubic
-            bv = bv_dict['FCC'](a=a)
+            bv_type = 'FCC'
         else:
             raise IndexError(f'Unknown cubic lattice with space group: {spg_cell.symbol}')
     else:
         raise IndexError(f'Unknown Spacegroup {spg_no}: {spg_cell.symbol}')
 
+    # Now get the Bravais lattice
+    bv = _get_bravais_lattice_usr(cell, bv_type)
     return bv
 
 
@@ -151,7 +155,7 @@ def _get_bravais_lattice_usr(cell, bv_type):
     elif bv_type == 'FCC':  # Face-Centred Cubic
         bv = bv_dict[bv_type](a=a)
     else:
-        # Raise error unless someone's reinvented crystallography and how 3D space works...
+        # Unless someone's reinvented crystallography and how 3D space works...
         raise IndexError(f'Unknown Bravais lattice: {bv_type}')
 
     return bv

--- a/CASTEPbands/spgutils.py
+++ b/CASTEPbands/spgutils.py
@@ -122,37 +122,21 @@ def _get_bravais_lattice_usr(cell, bv_type):
     # Since the ASE interface is not overloaded, we will have to
     # set the arguments ourselves here.
     # Lattice Parameters not specified have values implied by type of Bravais lattice.
-
     if bv_type == 'TRI':  # Triclinic lattice
         bv = bv_dict[bv_type](a=a, b=b, c=c,
                               alpha=alpha, beta=beta, gamma=gamma)
-    elif bv_type == 'MCL':  # Primitive Monoclinic
+    elif bv_type in ('MCL', 'MCLC'):  # Primitive/Base-centred (C-centred) Monoclinic
         bv = bv_dict[bv_type](a=a, b=b, c=c,
                               alpha=alpha)
-    elif bv_type == 'MCLC':  # Base-centred (C-centred) monoclinic
-        bv = bv_dict[bv_type](a=a, b=b, c=c,
-                              alpha=alpha)
-    elif bv_type == 'ORC':  # Primitive Orthorhombic
+    elif bv_type in ('ORC', 'ORCI', 'ORCF', 'ORCC'):  # Primitive or Body-/Face-Centred or A/C-Centred Orthorhombic
         bv = bv_dict[bv_type](a=a, b=b, c=c)
-    elif bv_type == 'ORCI':  # Body-Centred Orthorhombic
-        bv = bv_dict[bv_type](a=a, b=b, c=c)
-    elif bv_type == 'ORCF':  # Face-Centred Orthorhombic
-        bv = bv_dict[bv_type](a=a, b=b, c=c)
-    elif bv_type == 'ORCC':  # A/C-centred Orthorhombic
-        bv = bv_dict[bv_type](a=a, b=b, c=c)
-    elif bv_type == 'TET':  # Primitive Tetragonal
-        bv = bv_dict[bv_type](a=a, c=c)
-    elif bv_type == 'BCT':  # Body-Centred Tetragonal
+    elif bv_type in ('TET', 'BCT'):  # Primitive/Body-Centred Tetragonal
         bv = bv_dict[bv_type](a=a, c=c)
     elif bv_type == 'RHL':  # R-trigonal/Rhombohedral
         bv = bv_dict[bv_type](a=a, alpha=alpha)
     elif bv_type == 'HEX':  # Hexagonal
         bv = bv_dict[bv_type](a=a, c=c)
-    elif bv_type == 'CUB':  # Primitive/Simple Cubic
-        bv = bv_dict[bv_type](a=a)
-    elif bv_type == 'BCC':  # Body-Centred Cubic
-        bv = bv_dict[bv_type](a=a)
-    elif bv_type == 'FCC':  # Face-Centred Cubic
+    elif bv_type in ('CUB', 'BCC', 'FCC'):  # Primitive/Simple or Body-Centred or Face-Centred Cubic
         bv = bv_dict[bv_type](a=a)
     else:
         # Unless someone's reinvented crystallography and how 3D space works...

--- a/CASTEPbands/spgutils.py
+++ b/CASTEPbands/spgutils.py
@@ -1,0 +1,157 @@
+"""
+The module handles space group and crystallographic symmetry functionality.
+
+This is mainly needed for the determination of high-symmetry point labels within
+the Brillouin zone based on the symmetry of the Bravais lattice.
+"""
+# Created by: V Ravindran, 28/08/2024
+import ase.lattice as latt
+import ase.spacegroup as spg
+
+
+def _get_bravais_lattice_spg(cell):
+    """Determine the high-symmetry points uisng the spacegroup.
+
+    ASE will use just use the crystal system based on solely the lattice parameters
+    whereas CASTEP will utilise the space group, which will be particularly important
+    in e.g. magnetic materials where the computational cell may have a different crystal system
+    to the (conventional) crystallographic one.
+
+    For low-symmetry Bravais lattices where the special/high-symmetry points are
+    lattice parameter dependent, we will use the lattice parameters of the computational cell.
+
+    Author : V Ravindran 08/05/2024
+    Moved from Spectral to here and updated to return the Bravais lattice itself instead 28/08/2024
+
+    """
+    # Get all the Bravais lattices
+    bv_dict = latt.bravais_lattices
+
+    # Get the cell's lattice parameters
+    a, b, c, alpha, beta, gamma = cell.cell.cellpar()
+
+    # Get the space group information for this cell
+    spg_cell = spg.get_spacegroup(cell)
+    spg_no = spg_cell.no
+
+    # Get the first letter of the spacegroup in international notation.
+    # This gives the information about the Bravais lattice
+    bv_symb = spg_cell.symbol.split()[0].upper()
+
+    # Now use the space group to determine the crystal system.
+    # We can determine the actual Bravais lattice using the first
+    # letter of the international notation symbol.
+    #
+    # Like in CASTEP, particularly for low symmetry Bravais lattices
+    # where the high symmetry points depend on lattice parameters,
+    # we will use the computational cell's lattice parameters.
+    # Variations for each bravais lattice should be handled by ASE (in principle...)
+    if 1 <= spg_no <= 2:
+        # Triclinic lattice
+        bv = bv_dict['TRI'](a=a, b=b, c=c,
+                            alpha=alpha, beta=beta, gamma=gamma)
+    elif 3 <= spg_no <= 15:
+        # Monoclinic
+        if bv_symb == 'P':  # Primitive monoclinic
+            bv = bv_dict['MCL'](a=a, b=b, c=c,
+                                alpha=alpha)
+        elif bv_symb == 'C':  # Base-centred (C-centred) monoclinic
+            bv = bv_dict['MCLC'](a=a, b=b, c=c,
+                                 alpha=alpha)
+        else:
+            raise IndexError(f'Unknown monoclinic lattice with space group: {spg_cell.symbol}')
+    elif 16 <= spg_no <= 74:
+        # Orthorhombic
+        if bv_symb == 'P':  # Primitive Orthorhombic
+            bv = bv_dict['ORC'](a=a, b=b, c=c)
+        elif bv_symb == 'I':  # Body-Centred Orthorhombic
+            bv = bv_dict['ORCI'](a=a, b=b, c=c)
+        elif bv_symb == 'F':  # Face-Centred Orthorhombic
+            bv = bv_dict['ORCF'](a=a, b=b, c=c)
+        elif bv_symb == 'A' or bv_symb == 'C':  # A/C-centred
+            bv = bv_dict['ORCC'](a=a, b=b, c=c)
+        else:
+            raise IndexError(f'Unknown orthorhombic lattice with space group: {spg_cell.symbol}')
+    elif 75 <= spg_no <= 142:
+        # Tetragonal
+        if bv_symb == 'P':  # Primitive Tetragonal
+            bv = bv_dict['TET'](a=a, c=c)
+        elif bv_symb == 'I':  # Body-Centred Tetragonal
+            bv = bv_dict['BCT'](a=a, c=c)
+        else:
+            raise IndexError(f'Unknown tetragonal lattice with space group: {spg_cell.symbol}')
+    elif 143 <= spg_no <= 167:
+        # Trigonal
+        if bv_symb == 'R':  # R-trigonal/Rhombohedral
+            bv = bv_dict['RHL'](a=a, alpha=alpha)
+        elif bv_symb == 'P':  # Hexagonal
+            bv = bv_dict['HEX'](a=a, c=c)
+        else:
+            raise IndexError(f'Unknown trigonal lattice with space group: {spg_cell.symbol}')
+    elif 168 <= spg_no <= 194:
+        # Hexagonal
+        bv = bv_dict['HEX'](a=a, c=c)
+    elif 195 <= spg_no <= 230:
+        # Cubic
+        if bv_symb == 'P':  # Primitive/Simple Cubic
+            bv = bv_dict['CUB'](a=a)
+        elif bv_symb == 'I':  # Body-Centred Cubic
+            bv = bv_dict['BCC'](a=a)
+        elif bv_symb == 'F':  # Face-Centred Cubic
+            bv = bv_dict['FCC'](a=a)
+        else:
+            raise IndexError(f'Unknown cubic lattice with space group: {spg_cell.symbol}')
+    else:
+        raise IndexError(f'Unknown Spacegroup {spg_no}: {spg_cell.symbol}')
+
+    return bv
+
+
+def _get_bravais_lattice_usr(cell, bv_type):
+    # Get all the Bravais lattices
+    bv_dict = latt.bravais_lattices
+
+    # Get the cell's lattice parameters
+    a, b, c, alpha, beta, gamma = cell.cell.cellpar()
+
+    # Here begins the boring bit - there should be 14 Bravais lattices here!
+    # Since the ASE interface is not overloaded, we will have to
+    # set the arguments ourselves here.
+    # Lattice Parameters not specified have values implied by type of Bravais lattice.
+
+    if bv_type == 'TRI':  # Triclinic lattice
+        bv = bv_dict[bv_type](a=a, b=b, c=c,
+                              alpha=alpha, beta=beta, gamma=gamma)
+    elif bv_type == 'MCL':  # Primitive Monoclinic
+        bv = bv_dict[bv_type](a=a, b=b, c=c,
+                              alpha=alpha)
+    elif bv_type == 'MCLC':  # Base-centred (C-centred) monoclinic
+        bv = bv_dict[bv_type](a=a, b=b, c=c,
+                              alpha=alpha)
+    elif bv_type == 'ORC':  # Primitive Orthorhombic
+        bv = bv_dict[bv_type](a=a, b=b, c=c)
+    elif bv_type == 'ORCI':  # Body-Centred Orthorhombic
+        bv = bv_dict[bv_type](a=a, b=b, c=c)
+    elif bv_type == 'ORCF':  # Face-Centred Orthorhombic
+        bv = bv_dict[bv_type](a=a, b=b, c=c)
+    elif bv_type == 'ORCC':  # A/C-centred Orthorhombic
+        bv = bv_dict[bv_type](a=a, b=b, c=c)
+    elif bv_type == 'TET':  # Primitive Tetragonal
+        bv = bv_dict[bv_type](a=a, c=c)
+    elif bv_type == 'BCT':  # Body-Centred Tetragonal
+        bv = bv_dict[bv_type](a=a, c=c)
+    elif bv_type == 'RHL':  # R-trigonal/Rhombohedral
+        bv = bv_dict[bv_type](a=a, alpha=alpha)
+    elif bv_type == 'HEX':  # Hexagonal
+        bv = bv_dict[bv_type](a=a, c=c)
+    elif bv_type == 'CUB':  # Primitive/Simple Cubic
+        bv = bv_dict[bv_type](a=a)
+    elif bv_type == 'BCC':  # Body-Centred Cubic
+        bv = bv_dict[bv_type](a=a)
+    elif bv_type == 'FCC':  # Face-Centred Cubic
+        bv = bv_dict[bv_type](a=a)
+    else:
+        # Raise error unless someone's reinvented crystallography and how 3D space works...
+        raise IndexError(f'Unknown Bravais lattice: {bv_type}')
+
+    return bv


### PR DESCRIPTION
Tidied up the high-symmetry label assignment in the main Spectral module. 

In particular, all the space group/crystallographic symmetry bits now reside in the module spgutils. 
This modularises the package should these functions be needed elsewhere and also reduces the length of the Spectral module, namely the massive `__init__`. 

There is now also an option to override the Bravais lattice manually by the user which is useful when plotting band structures of defect states since typically these unit cells have no (space group: P1) symmetry. However, one may still wish to use the high-symmetry labels of the main crystal (e.g. primitive cubic). 

Also added missing types to Spectral class docstring. 

